### PR TITLE
Suppress --update up-to-date output unless --verbose

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -345,7 +345,9 @@ fn cmd_update(verbose: bool) -> Result<(), Box<dyn Error>> {
 
     // Compare versions
     if compare_versions(&latest_version, current_version) != std::cmp::Ordering::Greater {
-        println!("ovc is already up to date (version {current_version})");
+        if verbose {
+            println!("ovc is already up to date (version {current_version})");
+        }
         return Ok(());
     }
 


### PR DESCRIPTION
## Summary

- Guard the "already up to date" message in `cmd_update` behind `--verbose`, matching the existing pattern used for all other diagnostic output in that function

Closes #29