### PR TITLE
Custom --version with verbose metadata support

### DIFF
--- a/man/ovc.1
+++ b/man/ovc.1
@@ -4,10 +4,13 @@
 .SH NAME
 ovc \- OpenShift Client Version Control
 .SH SYNOPSIS
-\fBovc\fR [\fB\-l\fR|\fB\-\-list\fR] [\fB\-i\fR|\fB\-\-installed\fR] [\fB\-p\fR|\fB\-\-prune\fR] [\fB\-m\fR|\fB\-\-match\-server\fR] [\fB\-u\fR|\fB\-\-update\fR] [\fB\-k\fR|\fB\-\-insecure\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-\-completion\fR] [\fB\-\-version\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fIVERSION\fR] 
+\fBovc\fR [\fB\-\-version\fR] [\fB\-l\fR|\fB\-\-list\fR] [\fB\-i\fR|\fB\-\-installed\fR] [\fB\-p\fR|\fB\-\-prune\fR] [\fB\-m\fR|\fB\-\-match\-server\fR] [\fB\-u\fR|\fB\-\-update\fR] [\fB\-k\fR|\fB\-\-insecure\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-\-completion\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fIVERSION\fR] 
 .SH DESCRIPTION
 OpenShift Client Version Control
 .SH OPTIONS
+.TP
+\fB\-\-version\fR
+Print version
 .TP
 \fB\-l\fR, \fB\-\-list\fR \fI<VERSION>\fR
 List available versions from the mirror
@@ -32,9 +35,6 @@ Make the operation more talkative
 .TP
 \fB\-\-completion\fR \fI<SHELL>\fR
 Generate shell completion script (only bash is supported currently)
-.TP
-\fB\-\-version\fR
-Print version
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,9 +21,12 @@ pub enum StandaloneAction {
     about = "OpenShift Client Version Control",
     disable_version_flag = true
 )]
-#[command(arg(clap::Arg::new("version").long("version").action(clap::ArgAction::Version).help("Print version")))]
 #[allow(clippy::struct_excessive_bools)]
 pub struct Cli {
+    /// Print version
+    #[arg(long = "version")]
+    pub version: bool,
+
     /// Version to download
     #[arg(value_name = "VERSION")]
     pub target_version: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,18 @@ fn main() {
         return;
     }
 
+    // Handle --version (with optional --verbose for metadata)
+    if cli.version {
+        if cli.verbose {
+            println!("Version: {}", env!("CARGO_PKG_VERSION"));
+            println!("Source Code: https://github.com/t-c-l-o-u-d/ovc");
+            println!("Author: tcloud");
+        } else {
+            println!("{}", env!("CARGO_PKG_VERSION"));
+        }
+        return;
+    }
+
     let standalone = cli.standalone_action();
     let verbose = cli.verbose;
     let insecure = cli.insecure;

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -872,7 +872,20 @@ mod cli_basic_tests {
         let output = run_ovc(&["--version"]);
         assert!(output.status.success());
         let stdout = String::from_utf8_lossy(&output.stdout);
-        assert!(stdout.contains("ovc"));
+        // Should print only the version number, no "ovc" prefix
+        let version = env!("CARGO_PKG_VERSION");
+        assert_eq!(stdout.trim(), version);
+    }
+
+    #[test]
+    fn test_version_verbose_command() {
+        let output = run_ovc(&["--version", "--verbose"]);
+        assert!(output.status.success());
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let version = env!("CARGO_PKG_VERSION");
+        assert!(stdout.contains(&format!("Version: {version}")));
+        assert!(stdout.contains("Source Code: https://github.com/t-c-l-o-u-d/ovc"));
+        assert!(stdout.contains("Author: tcloud"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Replace clap's `ArgAction::Version` with a custom `--version` bool flag handled in the main dispatch
- `--version` now prints only the version number (e.g. `1.3.3`)
- `--version --verbose` prints version, source code URL, and author

Closes #27